### PR TITLE
Merge v0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Saturn contains a custom-made editor, interpreter, debugger and assembler for MI
 
 # Important Tasks
 - [ ] Memory Editing and Copying
-- [ ] Register Editing and Copying
+- [x] Register Editing and Copying
 - [x] Finding Text (Cmd + F)
 - [x] Finished Execution State
 - [x] Editor Performance (Smooth Cmd + A @ 4000 lines)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2385,7 +2385,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.6",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -2407,7 +2407,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.6",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.6"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece519cfaf36269ea69d16c363fa1d59ceba8296bbfbfc003c3176d01f2816ee"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2964,7 +2964,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.6",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -3022,7 +3022,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "titan"
 version = "0.1.0"
-source = "git+https://github.com/1whatleytay/titan.git?branch=main#47581855782f027cb36266893245984a40156b4b"
+source = "git+https://github.com/1whatleytay/titan.git?branch=main#96770f7ca9c8f2227020f80459037cba02eec27b"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -3087,9 +3087,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3688,9 +3688,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
 dependencies = [
  "memchr",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ checksum = "3c55d429bef56ac9172d25fecb85dc8068307d17acd74b377866b7a1ef25d3c8"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa"
+checksum = "a35b255461940a32985c627ce82900867c61db1659764d3675ea81963f72a4c6"
 dependencies = [
  "smallvec",
 ]
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -801,7 +801,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -818,7 +818,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
  "x11",
 ]
 
@@ -905,7 +905,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
  "winapi",
 ]
 
@@ -951,7 +951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4b192f8e65e9cf76cbf4ea71fa8e3be4a0e18ffe3d68b8da6836974cc5bad4"
 dependencies = [
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -981,7 +981,7 @@ checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -1022,7 +1022,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945"
+checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.47"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1733,9 +1733,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.82"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",
@@ -1793,7 +1793,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -2033,9 +2033,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2385,7 +2385,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -2407,7 +2407,16 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2636,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2654,20 +2663,20 @@ dependencies = [
  "cfg-expr 0.9.1",
  "heck 0.3.3",
  "pkg-config",
- "toml",
+ "toml 0.5.11",
  "version-compare 0.0.11",
 ]
 
 [[package]]
 name = "system-deps"
-version = "6.0.3"
+version = "6.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff"
+checksum = "555fc8147af6256f3931a36bb83ad0023240ce9cf2b319dec8236fd1f220b05f"
 dependencies = [
- "cfg-expr 0.11.0",
+ "cfg-expr 0.14.0",
  "heck 0.4.1",
  "pkg-config",
- "toml",
+ "toml 0.7.3",
  "version-compare 0.1.1",
 ]
 
@@ -2964,7 +2973,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -3080,10 +3089,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3092,6 +3116,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -3405,7 +3431,7 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "soup2-sys",
- "system-deps 6.0.3",
+ "system-deps 6.0.4",
 ]
 
 [[package]]
@@ -3688,9 +3714,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
@@ -3701,7 +3727,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2033,9 +2033,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -2385,7 +2385,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.6",
 ]
 
 [[package]]
@@ -2407,7 +2407,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.6",
 ]
 
 [[package]]
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
+checksum = "ece519cfaf36269ea69d16c363fa1d59ceba8296bbfbfc003c3176d01f2816ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2964,7 +2964,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.6",
 ]
 
 [[package]]
@@ -3022,7 +3022,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "titan"
 version = "0.1.0"
-source = "git+https://github.com/1whatleytay/titan.git?branch=main#b791373b03d472a9c7ffaeeb3c08e0a4d5628f68"
+source = "git+https://github.com/1whatleytay/titan.git?branch=main#47581855782f027cb36266893245984a40156b4b"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "atk"
@@ -110,9 +110,9 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
 dependencies = [
  "memchr",
  "serde",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
  "bitflags",
  "block",
@@ -407,7 +407,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smallvec",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -417,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -427,14 +427,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
-
-[[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "darling"
@@ -457,7 +451,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -468,7 +462,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -492,7 +486,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -672,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -687,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -697,15 +691,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -714,38 +708,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -947,7 +941,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1042,7 +1036,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1076,6 +1070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1092,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1199,10 +1199,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -1302,9 +1303,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libdbus-sys"
@@ -1567,7 +1568,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1618,7 +1619,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1640,7 +1641,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1690,18 +1691,19 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "open"
-version = "3.4.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ecf2487e799604735754d2c5896106785987b441b5aee58f242e4d4963179a"
+checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
 dependencies = [
  "pathdiff",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1720,7 +1722,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1731,9 +1733,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
 dependencies = [
  "autocfg",
  "cc",
@@ -1744,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c424bc68d15e0778838ac013b5b3449544d8133633d8016319e7e05a820b8c0"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
  "log",
  "serde",
@@ -1898,7 +1900,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1912,7 +1914,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1953,14 +1955,14 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plist"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9469799ca90293a376f68f6fcb8f11990d9cff55602cfba0ba83893c973a7f46"
+checksum = "9bd9647b268a3d3e14ff09c23201133a62589c658db02bb7388c7246aafe0590"
 dependencies = [
  "base64 0.21.0",
  "indexmap",
  "line-wrap",
- "quick-xml 0.26.0",
+ "quick-xml 0.28.1",
  "serde",
  "time",
 ]
@@ -2008,7 +2010,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2031,9 +2033,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -2049,18 +2051,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.26.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2148,12 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
-dependencies = [
- "cty",
-]
+checksum = "4f851a03551ceefd30132e447f07f96cb7011d6b658374f3aed847333adb5559"
 
 [[package]]
 name = "redox_syscall"
@@ -2177,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2197,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rfd"
@@ -2236,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
  "errno",
@@ -2362,31 +2361,31 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a382c72b4ba118526e187430bb4963cd6d55051ebf13d9b25574d379cc98d20"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef476a5790f0f6decbc66726b6e5d63680ed518283e64c7df415989d880954f"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -2402,13 +2401,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -2442,7 +2441,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2464,7 +2463,7 @@ checksum = "74064874e9f6a15f04c1f3cb627902d0e6b410abbf36668afa873c61889f1763"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2621,7 +2620,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2629,6 +2628,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2823,7 +2833,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -2939,22 +2949,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -3012,7 +3022,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "titan"
 version = "0.1.0"
-source = "git+https://github.com/1whatleytay/titan.git?branch=main#377e78d9cbfebae0d572ed78abd8a35f3dae5e55"
+source = "git+https://github.com/1whatleytay/titan.git?branch=main#ecf9b82b7f0499ad676af43bf01cc24cd5446d05"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -3044,7 +3054,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3077,9 +3087,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3106,7 +3116,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3165,9 +3175,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -3255,12 +3265,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -3297,7 +3306,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -3331,7 +3340,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3419,7 +3428,7 @@ checksum = "eaebe196c01691db62e9e4ca52c5ef1e4fd837dcae27dae3ada599b5a8fd05ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3520,7 +3529,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba01f98f509cb5dc05f4e5fc95e535f78260f15fea8fe1a8abdd08f774f1cee7"
 dependencies = [
- "syn",
+ "syn 1.0.109",
  "windows-tokens",
 ]
 
@@ -3537,12 +3546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3556,17 +3565,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3577,9 +3586,9 @@ checksum = "f838de2fe15fe6bac988e74b798f26499a8b21a9d97edec321e79b28d1d7f597"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3595,9 +3604,9 @@ checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3613,9 +3622,9 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3631,9 +3640,9 @@ checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3649,15 +3658,15 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3673,15 +3682,15 @@ checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "saturn"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "futures",
  "hex",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3022,7 +3022,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "titan"
 version = "0.1.0"
-source = "git+https://github.com/1whatleytay/titan.git?branch=main#ecf9b82b7f0499ad676af43bf01cc24cd5446d05"
+source = "git+https://github.com/1whatleytay/titan.git?branch=main#b791373b03d472a9c7ffaeeb3c08e0a4d5628f68"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saturn"
-version = "0.1.4"
+version = "0.1.5"
 description = "A modern MIPS IDE."
 authors = ["desgroup"]
 license = ""

--- a/src-tauri/src/build.rs
+++ b/src-tauri/src/build.rs
@@ -21,10 +21,16 @@ pub struct LineMarker {
 }
 
 #[derive(Serialize)]
+pub struct Breakpoint {
+    line: usize,
+    pcs: Vec<u32>
+}
+
+#[derive(Serialize)]
 #[serde(tag="status")]
 pub enum AssemblerResult {
     Error { marker: Option<LineMarker>, message: String, body: Option<String> },
-    Success { breakpoints: HashMap<u32, usize> }
+    Success { breakpoints: Vec<Breakpoint> }
 }
 
 impl AssemblerResult {
@@ -33,7 +39,10 @@ impl AssemblerResult {
     ) -> (Option<Binary>, AssemblerResult) {
         match result {
             Ok(binary) => {
-                let breakpoints = binary.source_breakpoints(source);
+                let breakpoints = binary.source_breakpoints(source)
+                    .into_iter()
+                    .map(|b| Breakpoint { line: b.line, pcs: b.pcs })
+                    .collect();
 
                 (Some(binary), AssemblerResult::Success { breakpoints })
             },

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,6 +15,8 @@ mod channels;
 mod midi;
 
 use std::sync::Mutex;
+use tauri::Manager;
+use tauri::WindowEvent::Destroyed;
 
 use crate::display::{display_protocol, FlushDisplayBody, FlushDisplayState};
 use crate::menu::{create_menu, handle_event};
@@ -74,6 +76,17 @@ fn main() {
         .manage(Mutex::new(FlushDisplayState::default()) as FlushDisplayBody)
         .manage(Mutex::new(MidiProviderContainer::None))
         .menu(menu)
+        .on_window_event(|event| {
+            if let Destroyed = event.event() {
+                // Relieve some pressure on tokio.
+                stop(
+                    event.window().state(),
+                    event.window().state()
+                )
+
+                // Assuming tokio will join threads for me if needed.
+            }
+        })
         .on_menu_event(handle_event)
         .invoke_handler(tauri::generate_handler![
             platform_shortcuts, // util

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -68,6 +68,15 @@ fn wake_sync(state: tauri::State<'_, DebuggerBody>) {
     pointer.delegate.lock().unwrap().sync_wake.notify_one();
 }
 
+#[tauri::command]
+fn is_debug() -> bool {
+    #[cfg(debug_assertions)]
+    { true }
+
+    #[cfg(not(debug_assertions))]
+    { false }
+}
+
 fn main() {
     let menu = create_menu();
 
@@ -107,7 +116,8 @@ fn main() {
             configure_display, // bitmap
             last_display, // bitmap
             midi_install,
-            wake_sync
+            wake_sync,
+            is_debug
         ])
         .register_uri_scheme_protocol("midi", midi_protocol)
         .register_uri_scheme_protocol("display", display_protocol)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,7 +22,7 @@ use crate::state::DebuggerBody;
 
 use crate::menu::platform_shortcuts;
 use crate::build::{assemble, disassemble, assemble_binary, configure_elf, configure_asm};
-use crate::execution::{resume, step, pause, stop};
+use crate::execution::{resume, pause, stop};
 use crate::debug::{read_bytes, write_bytes, set_register, swap_breakpoints};
 use crate::midi::{midi_protocol, midi_install, MidiProviderContainer};
 
@@ -83,7 +83,6 @@ fn main() {
             configure_elf, // build
             configure_asm, // build
             resume, // execution
-            step, // execution
             pause, // execution
             stop, // execution
             read_bytes, // debug

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -62,7 +62,7 @@ pub fn state_from_binary(binary: Binary, heap_size: u32) -> State<MemoryType> {
     }
 
     // Keeping this around temporarily.
-    let heap_end = 0x7FFFFFFCu32;
+    let heap_end = 0x80000000u32;
 
     let heap = Region {
         start: heap_end - heap_size,
@@ -73,17 +73,16 @@ pub fn state_from_binary(binary: Binary, heap_size: u32) -> State<MemoryType> {
 
     let mut state = State::new(binary.entry, memory);
 
-    state.registers.line[29] = heap_end;
+    state.registers.line[29] = heap_end - 4; // give some space
 
     state
 }
 
 pub fn setup_state(state: &mut State<MemoryType>) {
-    let screen = Region { start: 0x10008000, data: vec![0; 0x4000] };
-    // let keyboard = Region { start: 0xFFFF0000, data: vec![0; 0x100] };
+    let max_screen = 0x8000;
+    let screen = Region { start: 0x10008000, data: vec![0; max_screen] };
 
     state.memory.mount(screen);
-    // state.memory.mount(keyboard);
 
     state.registers.line[28] = 0x10008000
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Saturn",
-    "version": "0.1.4"
+    "version": "0.1.5"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/EditorBody.vue
+++ b/src/components/EditorBody.vue
@@ -224,7 +224,7 @@ function handleDown(event: MouseEvent) {
   const { x, y } = editorCoordinates(event)
 
   mouseDown = true
-  dropCursor(x, y, event.detail)
+  dropCursor(x, y, event.detail, event.shiftKey)
 }
 
 let lastX = null as number | null

--- a/src/components/EditorBody.vue
+++ b/src/components/EditorBody.vue
@@ -167,7 +167,7 @@ const stoppedIndex = computed(() => {
   }
 
   // Reactivity concern here (eh... not too bad, we just want to listen to changes in debug).
-  const point = execution.breakpoints?.pcToLine.get(registers.pc)
+  const point = execution.breakpoints?.pcToGroup.get(registers.pc)?.line
 
   return point ?? null
 })

--- a/src/components/console/BitmapTab.vue
+++ b/src/components/console/BitmapTab.vue
@@ -155,11 +155,14 @@ function unitCheck(value: number): string | null {
 }
 
 function mapKey(key: string): string | null {
-  if (key.length <= 1) {
-    return key
+  const lower = key.toLowerCase()
+
+  if (lower.length <= 1) {
+    return lower
   } else {
     switch (key) {
       case 'Enter': return '\n'
+      case 'Space': return ' '
       default: return null
     }
   }

--- a/src/components/console/BitmapTab.vue
+++ b/src/components/console/BitmapTab.vue
@@ -14,8 +14,8 @@
       <canvas
         ref="canvas"
         class="w-full h-full bitmap-display rounded"
-        :width="config.width * 4"
-        :height="config.height * 4"
+        :width="config.width"
+        :height="config.height"
       />
     </button>
 
@@ -276,20 +276,12 @@ async function renderFrameFallback(context: CanvasRenderingContext2D, execution:
     data.data[i + 3] = 255
   }
 
-  const resizeWidth = width * 4
-  const resizeHeight = height * 4
-
-  const image = await createImageBitmap(data, {
-    resizeWidth, resizeHeight,
-    resizeQuality: 'pixelated'
-  })
-
-  context.drawImage(image, 0, 0, resizeWidth, resizeHeight)
+  context.putImageData(data, 0, 0)
 }
 
 const protocol = convertFileSrc('', 'display')
 
-async function renderOrdered(
+function renderOrdered(
   context: CanvasRenderingContext2D,
   width: number, height: number, memory: Uint8Array
 ) {
@@ -299,15 +291,7 @@ async function renderOrdered(
     data.data[a] = memory[a]
   }
 
-  const resizeWidth = width * 4
-  const resizeHeight = height * 4
-
-  const image = await createImageBitmap(data, {
-    resizeWidth, resizeHeight,
-    resizeQuality: 'pixelated'
-  })
-
-  context.drawImage(image, 0, 0, resizeWidth, resizeHeight)
+  context.putImageData(data, 0, 0)
 }
 
 async function renderFrameProtocol(context: CanvasRenderingContext2D) {
@@ -325,7 +309,7 @@ async function renderFrameProtocol(context: CanvasRenderingContext2D) {
 
   const memory = new Uint8Array(await result.arrayBuffer())
 
-  await renderOrdered(context, width, height, memory)
+  renderOrdered(context, width, height, memory)
 }
 
 async function renderLastDisplay(context: CanvasRenderingContext2D) {

--- a/src/components/console/BitmapTab.vue
+++ b/src/components/console/BitmapTab.vue
@@ -7,36 +7,54 @@
       @click="focusSelf"
       @keydown="e => handleKey(e, false)"
       @keyup="e => handleKey(e, true)"
-      class="outline-none overflow-visible focus:ring-4 border border-neutral-700 rounded h-full shrink-0 mx-auto md:mx-0 max-w-full"
+      class="outline-none overflow-visible focus:ring-4 border border-neutral-700 rounded h-full shrink-0 max-w-full"
       :style="{ width: `${correctedWidth}px` }"
+      :class="{ 'mx-auto sm:mx-0': !state.small, 'mx-auto': state.small }"
     >
       <canvas
         ref="canvas"
         class="w-full h-full bitmap-display rounded"
-        :width="settings.bitmap.width * 4"
-        :height="settings.bitmap.height * 4"
+        :width="config.width * 4"
+        :height="config.height * 4"
       />
     </button>
 
-    <div class="p-4 hidden md:block flex flex-col content-center justify-center items-center align-center">
+    <div
+      class="p-4 hidden flex flex-col content-center justify-center items-center align-center"
+      :class="{ 'sm:block': !state.small }"
+    >
       <div class="text-lg font-light mb-4 flex items-center">
         Bitmap Display
       </div>
 
       <div class="text-neutral-300 ml-2">
         <div class="py-1">
-          <label for="bitmap-width" class="inline-block font-bold pr-4 w-32">Display Width</label>
-          <NumberField id="bitmap-width" v-model="settings.bitmap.width" :checker="sizeCheck" classes="text-xs" />
+          <label class="inline-block font-bold pr-4 w-32">Display Width</label>
+
+          <NumberField v-model="settings.bitmap.displayWidth" :clean-only="true" :checker="sizeCheck" classes="text-xs w-32" />
+
+          <span class="text-neutral-400 mx-3 text-xs font-bold">
+            Units
+          </span>
+
+          <NumberField v-model="settings.bitmap.unitWidth" :clean-only="true" :checker="unitCheck" classes="text-xs w-20" />
         </div>
 
         <div class="py-1">
-          <label for="bitmap-height" class="inline-block font-bold pr-4 w-32">Display Height</label>
-          <NumberField id="bitmap-height" v-model="settings.bitmap.height" :checker="sizeCheck" classes="text-xs" />
+          <label class="inline-block font-bold pr-4 w-32">Display Height</label>
+
+          <NumberField v-model="settings.bitmap.displayHeight" :clean-only="true" :checker="sizeCheck" classes="text-xs w-32" />
+
+          <span class="text-neutral-400 mx-3 text-xs font-bold">
+            Units
+          </span>
+
+          <NumberField v-model="settings.bitmap.unitHeight" :clean-only="true" :checker="unitCheck" classes="text-xs w-20" />
         </div>
 
         <div class="py-1">
-          <label for="bitmap-address" class="inline-block font-bold pr-4 w-32">Address</label>
-          <NumberField id="bitmap-address" v-model="settings.bitmap.address" :hex="true" :checker="memoryCheck" classes="text-xs" />
+          <label class="inline-block font-bold pr-4 w-32">Address</label>
+          <NumberField v-model="settings.bitmap.address" :hex="true" :checker="memoryCheck" classes="text-xs w-32" />
 
           <button
             class="rounded px-2 py-1 border border-neutral-700 font-bold text-xs ml-4 active:bg-slate-700"
@@ -80,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 
 import { ArrowLeftIcon } from '@heroicons/vue/24/solid'
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
@@ -90,17 +108,21 @@ import { settings } from '../../state/state'
 import NumberField from './NumberField.vue'
 import { convertFileSrc } from '@tauri-apps/api/tauri'
 import { ExecutionState, lastDisplay } from '../../utils/mips'
+import { displayConfig } from '../../utils/settings'
 
 const wrapper = ref(null as HTMLElement | null)
 const canvas = ref(null as HTMLCanvasElement | null)
 
 const gp = 0x10008000
 
-let lastHeight = settings.bitmap.height
-const correctedWidth = ref(settings.bitmap.width)
+const config = computed(() => displayConfig(settings.bitmap))
+
+let lastHeight = config.value.height
+const correctedWidth = ref(config.value.width)
 
 const state = reactive({
   interval: null as number | null,
+  small: false as boolean,
   useProtocol: true
 })
 
@@ -119,6 +141,14 @@ function memoryCheck(value: number): string | null {
 function sizeCheck(value: number): string | null {
   if (value <= 0 || value > 512) {
     return 'This field must be in the 1-512 range'
+  }
+
+  return null
+}
+
+function unitCheck(value: number): string | null {
+  if (value <= 0 || value > 32) {
+    return 'This field must be in the 1-32 range'
   }
 
   return null
@@ -154,9 +184,11 @@ function focusSelf() {
 let observer = null as ResizeObserver | null
 
 function fixWidth(height: number) {
-  const width = height / settings.bitmap.height * settings.bitmap.width
+  const width = height / config.value.height * config.value.width
 
   lastHeight = height
+
+  state.small = height < 140
 
   // Should not re-trigger this statement.
   correctedWidth.value = width
@@ -195,8 +227,7 @@ onUnmounted(() => {
   }
 })
 
-watch(() => settings.bitmap.width, recheckWidth)
-watch(() => settings.bitmap.height, recheckWidth)
+watch(() => settings.bitmap, recheckWidth, { deep: true })
 
 function checkConnected() {
   if (consoleData.execution) {
@@ -220,8 +251,7 @@ watch(() => consoleData.execution, checkConnected)
 async function renderFrameFallback(context: CanvasRenderingContext2D, execution: ExecutionState) {
   const memory = await execution.memoryAt(0x10008000, 64 * 64 * 4)
 
-  const width = settings.bitmap.width
-  const height = settings.bitmap.height
+  const { width, height } = config.value
 
   const pixels = width * height * 4
 
@@ -278,8 +308,7 @@ async function renderOrdered(
 }
 
 async function renderFrameProtocol(context: CanvasRenderingContext2D) {
-  const width = settings.bitmap.width
-  const height = settings.bitmap.height
+  const { width, height } = config.value
 
   const result = await fetch(protocol, {
     headers: {

--- a/src/components/console/Console.vue
+++ b/src/components/console/Console.vue
@@ -34,25 +34,25 @@
         <Tab
           title="Console"
           :selected="consoleData.tab === DebugTab.Console"
-          @mousedown="consoleData.tab = DebugTab.Console"
+          @mousedown="() => consoleData.tab = DebugTab.Console"
         />
 
         <Tab
           title="Registers"
           :selected="consoleData.tab === DebugTab.Registers"
-          @mousedown="consoleData.tab = DebugTab.Registers"
+          @mousedown="() => consoleData.tab = DebugTab.Registers"
         />
 
         <Tab
           title="Memory"
           :selected="consoleData.tab === DebugTab.Memory"
-          @mousedown="consoleData.tab = DebugTab.Memory"
+          @mousedown="() => consoleData.tab = DebugTab.Memory"
         />
 
         <Tab
           title="Bitmap"
           :selected="consoleData.tab === DebugTab.Bitmap"
-          @mousedown="consoleData.tab = DebugTab.Bitmap"
+          @mousedown="() => consoleData.tab = DebugTab.Bitmap"
         />
 
         <button class="w-10 h-10 ml-auto

--- a/src/components/console/ConsoleTab.vue
+++ b/src/components/console/ConsoleTab.vue
@@ -174,7 +174,7 @@ function handleDown(event: MouseEvent) {
   const { x, y } = editorCoordinates(event)
 
   mouseDown.value = true
-  dropCursor(x, y, event.detail)
+  dropCursor(x, y, event.detail, event.shiftKey)
 }
 
 const lineShift = 8

--- a/src/components/console/NumberField.vue
+++ b/src/components/console/NumberField.vue
@@ -10,6 +10,7 @@
       ]"
       v-model="state.value"
       @change="clean"
+      :disabled="!props.editable"
       @keydown.enter="clean"
     />
 
@@ -34,10 +35,12 @@ const props = withDefaults(defineProps<{
   modelValue: number,
   hex?: boolean,
   classes?: string
-  checker?: (value: number) => string | null
+  checker?: (value: number) => string | null,
+  editable?: boolean
 }>(), {
   hex: false,
-  classes: ''
+  classes: '',
+  editable: true
 })
 
 const emit = defineEmits(['update:modelValue'])

--- a/src/components/console/NumberField.vue
+++ b/src/components/console/NumberField.vue
@@ -74,6 +74,10 @@ watch(() => props.modelValue, value => {
   }
 })
 
+watch(() => props.hex, value => {
+  state.value = formatHex(props.modelValue, value)
+})
+
 function parse(leading: string): number | null {
   let result: number
 

--- a/src/components/console/RegistersTab.vue
+++ b/src/components/console/RegistersTab.vue
@@ -18,8 +18,9 @@
           v-for="register of section.values"
           :key="register.name"
           class="w-28 py-1 px-0.5 h-12"
+          :class="!consoleData.execution ? 'opacity-50' : ''"
         >
-          <div class="text-xs pl-2" :class="[section.classes, register.value === undefined ? 'opacity-50' : '']">
+          <div class="text-xs pl-2 group" :class="section.classes">
             {{ register.name }}
           </div>
 
@@ -34,6 +35,7 @@
             :model-value="register.value"
             @update:model-value="value => setRegister(register.id, value)"
             :checker="checker"
+            :editable="!!consoleData.execution"
             :hex="true"
           />
         </div>

--- a/src/components/console/RegistersTab.vue
+++ b/src/components/console/RegistersTab.vue
@@ -36,10 +36,33 @@
             @update:model-value="value => setRegister(register.id, value)"
             :checker="checker"
             :editable="!!consoleData.execution"
-            :hex="true"
+            :hex="settings.registers.format === RegisterFormat.Hexadecimal"
           />
         </div>
       </div>
+    </div>
+
+    <div class="w-full h-12" />
+
+    <div class="
+      absolute border border-neutral-800 bottom-0 right-0 bg-neutral-900
+      rounded text-neutral-300 text-xs mr-6 mb-6 overflow-hidden
+    ">
+      <button
+        class="px-3 py-1 transition-colors"
+        :class="buttonClasses(RegisterFormat.Hexadecimal)"
+        @click="() => settings.registers.format = RegisterFormat.Hexadecimal"
+      >
+        Hex
+      </button>
+
+      <button
+        class="px-3 py-1 transition-colors"
+        :class="buttonClasses(RegisterFormat.Decimal)"
+        @click="() => settings.registers.format = RegisterFormat.Decimal"
+      >
+        Dec
+      </button>
     </div>
   </div>
 </template>
@@ -53,6 +76,15 @@ import { Cog6ToothIcon, Square3Stack3DIcon } from '@heroicons/vue/24/outline'
 import { RegisterFormat } from '../../utils/settings'
 import { Registers } from '../../utils/mips'
 import NumberField from './NumberField.vue'
+
+function buttonClasses(format: RegisterFormat) {
+  const use = settings.registers.format === format
+
+  return {
+    'hover:bg-slate-800 bg-neutral-800': use,
+    'hover:bg-slate-700': !use
+  }
+}
 
 const registers = [
   '$zero', '$at', '$v0', '$v1',

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,12 @@ import './style.css'
 import App from './App.vue'
 import { setupEvents } from './utils/events'
 import { setupShortcuts } from './utils/platform-shortcuts'
+import { setupWindow } from './utils/window'
 
 createApp(App)
   .mount('#app')
+
+setupWindow()
 
 setupShortcuts()
   .then(() => {})

--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -541,6 +541,10 @@ export function useCursor(
         break
 
       case 'z': {
+        if (event.shiftKey) {
+          return // do nothing, ignore "redo"
+        }
+
         const frame = editor().undo()
 
         suggestions?.dismissSuggestions()
@@ -588,8 +592,18 @@ export function useCursor(
         break
 
       case 'Tab':
-        hitTab(event.shiftKey)
         event.preventDefault()
+
+        if (!event.shiftKey && suggestions && suggestions.flushSuggestions()) {
+          const suggestion = suggestions.mergeSuggestion()
+
+          if (suggestion) {
+            return applyMergeSuggestion(suggestion)
+          }
+        } else {
+          hitTab(event.shiftKey)
+        }
+
         break
 
       case 'Backspace':

--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -383,18 +383,21 @@ export function useCursor(
       }
     } else {
       const alignment = settings.tabSize
-      const tabs = ' '.repeat(alignment)
 
       if (region) {
+        const tabs = ' '.repeat(alignment)
+
         for (let line = region.startLine; line <= region.endLine; line++) {
           editor().put({ line, index: 0 }, tabs)
 
           adjustCursor(line, +alignment)
         }
       } else {
-        editor().put(value, tabs)
+        const spaces = settings.tabSize - (value.index % settings.tabSize)
 
-        putCursor({ line: value.line, index: value.index + alignment })
+        editor().put(value, ' '.repeat(spaces))
+
+        putCursor({ line: value.line, index: value.index + spaces })
       }
     }
   }

--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -3,7 +3,7 @@ import { computed, ComputedRef } from 'vue'
 import { MergeSuggestion, SuggestionsInterface } from './suggestions'
 import { SizeCalculator } from './query/text-size'
 import { consumeBackwards, consumeDirection, consumeForwards } from './query/alt-consume'
-import { hasActionKey } from './query/shortcut-key'
+import { hasActionKey, hasAltKey } from './query/shortcut-key'
 import { selectionRange, CursorState } from './tabs'
 import { EditorSettings } from './settings'
 import { grabWhitespace } from './languages/language'
@@ -570,11 +570,11 @@ export function useCursor(
 
     switch (event.key) {
       case 'ArrowLeft':
-        moveLeft(event.altKey, event.shiftKey)
+        moveLeft(hasAltKey(event), event.shiftKey)
         break
 
       case 'ArrowRight':
-        moveRight(event.altKey, event.shiftKey)
+        moveRight(hasAltKey(event), event.shiftKey)
         break
 
       case 'ArrowDown':
@@ -624,9 +624,9 @@ export function useCursor(
           let nextPosition: SelectionIndex
 
           if (doDelete) {
-            nextPosition = editor().deleteForwards(value, event.altKey)
+            nextPosition = editor().deleteForwards(value, hasAltKey(event))
           } else {
-            nextPosition = editor().backspace(value, event.altKey, settings.tabSize)
+            nextPosition = editor().backspace(value, hasAltKey(event), settings.tabSize)
           }
 
           putCursor(nextPosition)

--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -29,7 +29,7 @@ export interface CursorInterface {
   getSelection(): string | null
   dropSelection(): void
   pasteText(text: string): void
-  dropCursor(x: number, y: number, detail?: number): void
+  dropCursor(x: number, y: number, detail?: number, shift?: boolean): void
   dragTo(x: number, y: number): void
   cursorCoordinates(x: number, y: number): SelectionIndex
   lineStart(line: number): number
@@ -695,7 +695,7 @@ export function useCursor(
     return { line, index }
   }
 
-  function dropCursor(x: number, y: number, detail?: number) {
+  function dropCursor(x: number, y: number, detail?: number, shift?: boolean) {
     const index = cursorCoordinates(x, y)
 
     if (detail === 2) {
@@ -733,7 +733,16 @@ export function useCursor(
       putCursor(end, current)
       current.highlight = alignCursor(start)
     } else {
-      cursor().highlight = null
+      const value = cursor()
+
+      if (shift) {
+        if (!value.highlight) {
+          value.highlight = { line: value.line, index: value.index }
+        }
+      } else {
+        value.highlight = null
+      }
+
       editor().commit()
       suggestions?.dismissSuggestions()
 

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -66,9 +66,6 @@ function clearDebug() {
 }
 
 function closeExecution() {
-  clearDebug()
-
-  consoleData.registers = null
   consoleData.execution = null
 }
 

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,5 +1,6 @@
 import { consumeBackwards, consumeForwards, consumeSpace } from './query/alt-consume'
 import { grabWhitespace } from './languages/language'
+import { splitLines } from './split-lines'
 
 export interface SelectionIndex {
   line: number,
@@ -270,7 +271,7 @@ export class Editor {
 
 // Technical Debt: insert vs paste (concern: speed for splitting by \n)
   paste(index: SelectionIndex, text: string): SelectionIndex {
-    const textLines = text.split('\n')
+    const textLines = splitLines(text)
 
     if (!textLines.length) {
       return index

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -9,6 +9,7 @@ import { find, suggestions, tabsState, createTab, closeTab, loadElf, tab } from 
 import { appWindow } from '@tauri-apps/api/window'
 import { watch } from 'vue'
 import { MidiNote, playNote } from './midi'
+import { splitLines } from './split-lines'
 
 export enum PromptType {
   NeverPrompt,
@@ -33,7 +34,7 @@ export async function openTab(file: SelectedFile<string | Uint8Array>) {
 
   switch (typeof data) {
     case 'string':
-      const split = data.split('\n')
+      const split = splitLines(data)
 
       createTab(name, split.length ? split : [''], path)
       break

--- a/src/utils/languages/mips/lexer.ts
+++ b/src/utils/languages/mips/lexer.ts
@@ -187,6 +187,8 @@ function readItem(line: string, index: number, initial: boolean): Item {
     }
 
     case ',':
+    case '+':
+    case '-':
     case '(':
     case ')':
     case ':':

--- a/src/utils/mips.ts
+++ b/src/utils/mips.ts
@@ -44,7 +44,7 @@ export type BinaryResult = {
   result: AssemblerResult
 }
 
-interface BitmapConfig {
+export interface BitmapConfig {
   width: number
   height: number
   address: number

--- a/src/utils/query/shortcut-key.ts
+++ b/src/utils/query/shortcut-key.ts
@@ -1,8 +1,8 @@
 import { UAParser } from 'ua-parser-js'
 
-function metaKeyPlatform(): boolean {
-  const os = new UAParser(navigator.userAgent).getOS()
+const os = new UAParser(navigator.userAgent).getOS()
 
+function metaKeyPlatform(): boolean {
   switch (os.name) {
     case 'Mac OS': return true
     default: return false
@@ -16,6 +16,15 @@ interface ActionMarkedEvent {
   ctrlKey: boolean
 }
 
+interface AltMarkedEvent {
+  altKey: boolean
+  ctrlKey: boolean
+}
+
 export function hasActionKey(event: ActionMarkedEvent): boolean {
   return isMetaKey ? event.metaKey : event.ctrlKey
+}
+
+export function hasAltKey(event: AltMarkedEvent): boolean {
+  return event.altKey || (isMetaKey && event.ctrlKey)
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,7 +1,7 @@
 import { reactive, watch } from 'vue'
 import { BitmapConfig, configureDisplay } from './mips'
 
-const settingsVersion = 2
+const settingsVersion = 3
 
 export interface BitmapSettings {
   displayWidth: number

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -73,8 +73,8 @@ function toStorage(settings: Settings) {
 
 export function displayConfig(bitmap: BitmapSettings): BitmapConfig {
   return {
-    width: Math.floor(bitmap.displayWidth / bitmap.unitWidth),
-    height: Math.floor(bitmap.displayHeight / bitmap.unitHeight),
+    width: Math.ceil(bitmap.displayWidth / bitmap.unitWidth),
+    height: Math.ceil(bitmap.displayHeight / bitmap.unitHeight),
     address: bitmap.address
   }
 }

--- a/src/utils/split-lines.ts
+++ b/src/utils/split-lines.ts
@@ -1,0 +1,3 @@
+export function splitLines(text: string) {
+  return text.split(/\r?\n/)
+}

--- a/src/utils/tabs.ts
+++ b/src/utils/tabs.ts
@@ -7,6 +7,7 @@ import { PromptType, saveTab } from './events'
 import { SaveModalResult, useSaveModal } from './save-modal'
 import { closeWindow } from './window'
 import { readFile } from './query/select-file'
+import { splitLines } from './split-lines'
 
 export type CursorState = SelectionIndex & {
   highlight: SelectionIndex | null
@@ -138,25 +139,18 @@ export function useTabs(): TabsResult {
 
     for (const tab of state.tabs) {
       const title = tab.title || 'Untitled'
-      let lines = ['']
-
+      let data: string | null
       if (tab.path) {
-        const { data } = await readFile(tab.path)
-
-        if (!data) {
-          continue
-        }
-
-        lines = data.split('\n')
+        data = (await readFile(tab.path)).data
       } else {
-        const data = localStorage.getItem(backupKey(tab.uuid))
-
-        if (!data) {
-          continue
-        }
-
-        lines = data.split('\n')
+        data = localStorage.getItem(backupKey(tab.uuid))
       }
+
+      if (!data) {
+        continue
+      }
+
+      const lines = splitLines(data)
 
       editor.tabs.push({
         uuid: tab.uuid,

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,4 +1,33 @@
 import { appWindow } from '@tauri-apps/api/window'
+import { invoke } from '@tauri-apps/api'
+import { hasActionKey } from './query/shortcut-key'
+
+export function setupWindow() {
+  window.addEventListener('keydown', event => {
+    // Prevent the Ctrl + R refresh.
+    if (hasActionKey(event) && event.key === 'r') {
+      event.preventDefault()
+    }
+  })
+
+  const handler = (event: Event) => {
+    // Don't bring up the "reload" context menu. It's note great!
+    event.preventDefault()
+  }
+
+  window.addEventListener('contextmenu', handler)
+
+  // Why this convoluted?
+  //  - I want to have the context menu available on --debug and vite builds.
+  //  - import.meta.env.DEV is false on --debug builds.
+  //  - #[cfg(debug_assertions)] seems like the best way find if the debug flag is set.
+  invoke('is_debug')
+    .then(result => {
+      if (result) {
+        window.removeEventListener('contextmenu', handler)
+      }
+    })
+}
 
 // Restricting tauri calls to certain files.
 export async function closeWindow() {


### PR DESCRIPTION
Changes (QOL release):

 - `.word` directive will now take label names
 - Anchor breakpoints introduced (to avoid the need for stepping multiple times on pseudo-instructions)
 - I-Type assembler instructions will no-longer overflow silently (with large immediates > 32768)
 - Register tab keeps the state of registers even after the program terminates
 - Registers in the registers tab can be viewed in Hex or Decimal form
 - Units added to the display dialog (to avoid confusion with MARS)
 - Ctrl, Tab, Shift work in more highlighting and autocomplete interactions